### PR TITLE
Upgrade data-of-loathing to v3

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { createClient } from "data-of-loathing";
+import { createClient, Monster } from "data-of-loathing";
 import { useLocalStorage } from "usehooks-ts";
 import { useEffect, useRef } from "react";
 import { Fireworks } from "@fireworks-js/react";
@@ -21,50 +21,37 @@ import { useMemo } from "react";
 const client = createClient();
 
 export async function loader() {
-  // Run all queries in parallel
-  const [lastUpdate, currentEggs, { allMonsters }, history] = await Promise.all(
-    [
-      getLastUpdate(),
-      db
-        .selectFrom("EggnetMonitor")
-        .select(["monster_id", "eggs_donated"])
-        .execute(),
-      client.query({
-        allMonsters: {
-          nodes: {
-            name: true,
-            id: true,
-            image: true,
-            wiki: true,
-            nocopy: true,
-          },
-        },
-      }),
-      db
-        .selectFrom("eggnet_history")
-        .select(["timestamp", "eggs_donated"])
-        .orderBy("timestamp", "asc")
-        .execute(),
-    ],
-  );
+  await client.load();
+
+  const [lastUpdate, currentEggs, dolMonsters, history] = await Promise.all([
+    getLastUpdate(),
+    db
+      .selectFrom("EggnetMonitor")
+      .select(["monster_id", "eggs_donated"])
+      .execute(),
+    client.query.findAll(Monster),
+    db
+      .selectFrom("eggnet_history")
+      .select(["timestamp", "eggs_donated"])
+      .orderBy("timestamp", "asc")
+      .execute(),
+  ]);
 
   const monsterEggsById = new Map(
     currentEggs.map((m) => [m.monster_id, m.eggs_donated] as const),
   );
 
-  const monsters =
-    allMonsters?.nodes
-      .filter((n) => n !== null)
-      .filter((m) => monsterEggsById.has(m.id))
-      .map((m) => ({
-        id: m.id,
-        name: m.name,
-        image: m.image,
-        wiki: m.wiki,
-        nocopy: m.nocopy,
-        priority: priorities[m.id] ?? 0,
-        eggs: monsterEggsById.get(m.id) ?? 0,
-      })) ?? [];
+  const monsters = dolMonsters
+    .filter((m) => monsterEggsById.has(m.id))
+    .map((m) => ({
+      id: m.id,
+      name: m.name,
+      image: m.image,
+      wiki: m.wiki ?? null,
+      nocopy: m.nocopy,
+      priority: priorities[m.id] ?? 0,
+      eggs: monsterEggsById.get(m.id) ?? 0,
+    }));
 
   // Ignore nocopy monsters for progress calculation (e.g. embering hulk and infinite meat bug)
   const progressMonsters = monsters.filter((m) => !m.nocopy);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@react-router/node": "^7.9.6",
     "@react-router/serve": "^7.9.6",
     "clsx": "^2.1.1",
-    "data-of-loathing": "^2.6.0",
+    "data-of-loathing": "^3.1.2",
     "entities": "^7.0.0",
     "express": "^5.1.0",
     "isbot": "^5.1.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mikro-orm/core@npm:^7.0.14":
+  version: 7.0.14
+  resolution: "@mikro-orm/core@npm:7.0.14"
+  peerDependencies:
+    dataloader: 2.2.3
+  peerDependenciesMeta:
+    dataloader:
+      optional: true
+  checksum: 10c0/383e42e23d7f718a22232e0a1fa313e18c08ac9fa5876ead9a27306f4c7428bee6c16a31f553e50f43223fe93bee51275b993f1b0b88101dc66c390ba5421d46
+  languageName: node
+  linkType: hard
+
+"@mikro-orm/sql@npm:^7.0.14":
+  version: 7.0.14
+  resolution: "@mikro-orm/sql@npm:7.0.14"
+  dependencies:
+    kysely: "npm:0.28.17"
+  peerDependencies:
+    "@mikro-orm/core": 7.0.14
+  checksum: 10c0/5fd6fde8cf8b13625cd2aff36a331dfca41c2dbb107605d438f0c0620f2578c9ada3881f8aaf8c5626c8309514dc3913d679ef6be9f6a91c31d126f2e09397ab
+  languageName: node
+  linkType: hard
+
 "@mjackson/node-fetch-server@npm:^0.2.0":
   version: 0.2.0
   resolution: "@mjackson/node-fetch-server@npm:0.2.0"
@@ -1274,6 +1297,13 @@ __metadata:
   version: 7.0.2
   resolution: "@sindresorhus/is@npm:7.0.2"
   checksum: 10c0/50881c9b651e189972087de9104e0d259a2a0dc93c604e863b3be1847e31c3dce685e76a41c0ae92198ae02b36d30d07b723a2d72015ce3cf910afc6dc337ff5
+  languageName: node
+  linkType: hard
+
+"@sqlite.org/sqlite-wasm@npm:~3.51.2-build9":
+  version: 3.51.2-build9
+  resolution: "@sqlite.org/sqlite-wasm@npm:3.51.2-build9"
+  checksum: 10c0/2b9c4d3df7b2cf84c1b311ac276c19692d8ccad4a4b34a1a739e1eb3b8938c6be4e64a98d51b7ea6e9ad5000a912d4ed0c25eec146f7eb468fa343b7ce491a08
   languageName: node
   linkType: hard
 
@@ -2226,10 +2256,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-of-loathing@npm:^2.6.0":
-  version: 2.6.0
-  resolution: "data-of-loathing@npm:2.6.0"
-  checksum: 10c0/de440bda79eb71a973c06ab290305fc584cd09b01716f5cd24a218ea1ab316e0edfd990a843c1181a5ef7698e91193901ce4212abb758c487d10015c235f8782
+"data-of-loathing@npm:^3.1.2":
+  version: 3.1.3
+  resolution: "data-of-loathing@npm:3.1.3"
+  dependencies:
+    "@mikro-orm/core": "npm:^7.0.14"
+    "@mikro-orm/sql": "npm:^7.0.14"
+    "@sqlite.org/sqlite-wasm": "npm:~3.51.2-build9"
+    env-paths: "npm:^4.0.0"
+    kysely: "npm:^0.28.17"
+  peerDependencies:
+    vite: ">=5.0.0"
+    vite-plugin-node-polyfills: ^0.26.0
+  peerDependenciesMeta:
+    vite:
+      optional: true
+    vite-plugin-node-polyfills:
+      optional: true
+  checksum: 10c0/edbffbb4a18edb03e9ca48feb281b4161ea350217474000b7c21993fca49f1f592a4fc935d7a250f860140afe398aa5810100794fd32f621a5fe0612abd3d5e3
   languageName: node
   linkType: hard
 
@@ -2418,7 +2462,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@types/react-is": "npm:^19.2.0"
     clsx: "npm:^2.1.1"
-    data-of-loathing: "npm:^2.6.0"
+    data-of-loathing: "npm:^3.1.2"
     entities: "npm:^7.0.0"
     express: "npm:^5.1.0"
     isbot: "npm:^5.1.32"
@@ -2511,6 +2555,15 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "env-paths@npm:4.0.0"
+  dependencies:
+    is-safe-filename: "npm:^0.1.0"
+  checksum: 10c0/13ee7fa4047786ca28f1fbf2239606f8a53304bdf71bfc426e95f806e429060181205316f2c45b4ac560e81c854ded5a45fd9dc3105414c01d504b3469a1294b
   languageName: node
   linkType: hard
 
@@ -3432,6 +3485,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-safe-filename@npm:^0.1.0":
+  version: 0.1.1
+  resolution: "is-safe-filename@npm:0.1.1"
+  checksum: 10c0/45c35d2253b96348e2c26590e14feed51d1e6b72aaa567930ccb34e68c0eef00ebcf3b7e01b46bf45e578a27355cd8f5bc12f7d6d79a34d33dc93d4560c0f6b6
+  languageName: node
+  linkType: hard
+
 "is-stream@npm:^4.0.1":
   version: 4.0.1
   resolution: "is-stream@npm:4.0.1"
@@ -3604,6 +3664,13 @@ __metadata:
   bin:
     kysely: dist/bin.js
   checksum: 10c0/a641aefee05cf415510214ecc527b6512592b8bc3883bacbed6112af5454995f3d5a944ac9da16eea38b3c24afdecd73621629756cd8e29424c867fac4b68116
+  languageName: node
+  linkType: hard
+
+"kysely@npm:0.28.17, kysely@npm:^0.28.17":
+  version: 0.28.17
+  resolution: "kysely@npm:0.28.17"
+  checksum: 10c0/70573292d8d60a1e29be9b432c1b25fe21d4806ecd5e9859b5ba8d2af799769878f4b3d91731ffe3e03744c7291476fe843640d31741f3637e20c3c49afea3c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrades `data-of-loathing` from v2 to v3.

v3 replaces the GraphQL API with a SQLite/MikroORM client. The DB is downloaded from `https://data.loathers.net/dol.sqlite` and cached at `~/.cache/data-of-loathing/`, re-fetching only when the ETag changes.

## Changes

- `client.query({...})` (GraphQL) → `client.query.findAll(Monster)` (MikroORM EntityManager)
- `await client.load()` must be called before querying to initialise the ORM
- `image` is now `string[]` (already handled by `Monster.tsx`)
- `wiki` coerced from `string | undefined` to `string | null`